### PR TITLE
(feat) cli validate & to-json both accept multiple files & stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ schema.validate(myMap, 'MyMap')
 This executable has two commands that operate on files or stdin.
 
   * `ipld-schema validate [files...]`
-  * `ipld-schema to-json [-t] [file]`
+  * `ipld-schema to-json [-t] [files...]`
+
+Both commands take either .ipldsch or .md files. When using .md files, `ipld-schema` will extract any \`\`\` code blocks using the `ipldsch` or `sh` language codes.
 
 ### Validation
 
@@ -80,8 +82,6 @@ $ ipld-schema validate README.md
 Validated README.md ...
 ```
 
-`ipld-schema validate` for Markdown files will extract any \`\`\` code blocks using the `ipldsch` or `sh` language codes.
-
 Alternatively, you can provide IPLD schema data via stdin:
 
 ```
@@ -91,7 +91,7 @@ Validated <stdin> ...
 
 ### JSONification
 
-The `to-json` command will take an .ipldsch` file and print a JSON form of its schema representation.
+The `to-json` command will take one or more .ipldsch or .md files and print a JSON form of the schemas found within.
 
 ```
 $ ipld-schema to-json simple-struct.ipldsch

--- a/bin/collect-input.js
+++ b/bin/collect-input.js
@@ -1,0 +1,64 @@
+const getStdin = require('get-stdin')
+const fs = require('fs').promises
+
+function stripMarkdown (str) {
+  str = str.split('\n')
+  const stripped = []
+  let inBlock = false
+  let blockCount = 0
+
+  for (const line of str) {
+    if (inBlock && /^\s*```/.test(line)) {
+      inBlock = false
+      stripped.push('')
+    } else if (inBlock) {
+      stripped.push(line)
+    } else if (/^\s*```\s*(ipldsch|sh)\s*$/.test(line)) {
+      inBlock = true
+      blockCount++
+      stripped.push('')
+    } else {
+      stripped.push('')
+    }
+  }
+
+  return blockCount ? stripped.join('\n') : ''
+}
+
+async function read (filename) {
+  return fs.readFile(filename, 'utf8')
+}
+
+async function collectInput (files) {
+  let input = []
+
+  if (!files.length) {
+    const contents = await getStdin()
+    if (!contents) {
+      throw new Error('No input provided via stdin')
+    }
+    input.push({ filename: '<stdin>', contents })
+  } else {
+    for (const filename of files) {
+      if (filename.endsWith('.ipldsch')) {
+        input.push({ filename, contents: await read(filename) })
+      } else if (filename.endsWith('.md')) {
+        input.push({ filename, contents: stripMarkdown(await read(filename)) })
+      } else {
+        console.error(`Ignoring "${filename}" (wrong suffix)`)
+      }
+    }
+  }
+
+  input = input.filter(({ filename, contents }) => {
+    if (!contents) {
+      console.error(`Ignoring "${filename}" (no IPLD Schema contents)`)
+      return false
+    }
+    return true
+  })
+
+  return input
+}
+
+module.exports = collectInput

--- a/bin/validate.js
+++ b/bin/validate.js
@@ -1,65 +1,16 @@
 const parser = require('../parser')
 const { transformError } = require('../util')
-const getStdin = require('get-stdin')
-const fs = require('fs').promises
-
-function stripMarkdown (str) {
-  str = str.split('\n')
-  const stripped = []
-  let inBlock = false
-  let blockCount = 0
-
-  for (const line of str) {
-    if (inBlock && /^\s*```/.test(line)) {
-      inBlock = false
-      stripped.push('')
-    } else if (inBlock) {
-      stripped.push(line)
-    } else if (/^\s*```\s*(ipldsch|sh)\s*$/.test(line)) {
-      inBlock = true
-      blockCount++
-      stripped.push('')
-    } else {
-      stripped.push('')
-    }
-  }
-
-  return blockCount ? stripped.join('\n') : ''
-}
-
-async function read (filename) {
-  return fs.readFile(filename, 'utf8')
-}
+const collectInput = require('./collect-input')
 
 async function validate (files) {
-  const input = []
-  if (!files.length) {
-    const contents = await getStdin()
-    if (!contents) {
-      throw new Error('No input provided via stdin')
-    }
-    input.push({ filename: '<stdin>', contents })
-  } else {
-    for (const filename of files) {
-      if (filename.endsWith('.ipldsch')) {
-        input.push({ filename, contents: await read(filename) })
-      } else if (filename.endsWith('.md')) {
-        input.push({ filename, contents: stripMarkdown(await read(filename)) })
-      } else {
-        console.error(`Ignoring "${filename}" (wrong suffix)`)
-      }
-    }
-  }
+  const input = await collectInput(files)
 
   for (const { filename, contents } of input) {
-    if (!contents) {
-      console.error(`File ${filename} has no IPLD schema contents`)
-      continue
-    }
     try {
       parser.parse(contents)
     } catch (err) {
-      throw new Error(`Could not validate ${filename}: ${transformError(err).message}`) // discard useless extra info
+      console.error(`Could not validate ${filename}: ${transformError(err).message}`) // discard useless extra info
+      process.exit(1)
     }
     console.error(`Validated ${filename} ...`)
   }

--- a/test/_split-schema-schema.js
+++ b/test/_split-schema-schema.js
@@ -1,0 +1,61 @@
+// A run-once script to split up schema-schema.ipldsch into a markdown file per type
+// for the purpose of test fixtures
+
+const fs = require('fs').promises
+const path = require('path')
+
+async function run () {
+  let schemaText = await fs.readFile(path.join(__dirname, 'fixtures/schema-schema.ipldsch'), 'utf8')
+  schemaText = schemaText.split('\n')
+  const outDir = path.join(__dirname, 'fixtures/schema-schema/')
+  await fs.mkdir(outDir, { recursive: true })
+
+  let block = []
+  let inType = null
+  let head = true
+
+  async function writeBlock () {
+    if (block[block.length - 1]) {
+      block.push(null)
+    }
+    block[block.length - 1] = '```'
+    block.push('')
+    const file = path.join(outDir, `${inType}.md`)
+    await fs.writeFile(file, block.join('\n'), 'utf8')
+    console.log('Wrote', inType, 'to', file)
+    block = []
+    inType = null
+  }
+
+  for (const line of schemaText) {
+    if (head) {
+      if (!line) {
+        head = false
+      }
+      continue
+    }
+    if (/^type/.test(line)) {
+      inType = line.split(' ')[1]
+      block.push('')
+      block.push('```ipldsch')
+    } else if (inType && line.startsWith('#')) {
+      await writeBlock()
+    }
+
+    if (!block.length) {
+      const title = line.match(/[A-Z]\w+/)
+      block.push(`# schema-schema: \`${title[0]}\``)
+      block.push('')
+    }
+    block.push(line.replace(/^#+\s?/, ''))
+  }
+
+  if (inType) {
+    await writeBlock()
+  }
+}
+
+run().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -1,0 +1,138 @@
+const path = require('path')
+const fs = require('fs')
+const { execFile } = require('child_process')
+const tap = require('tap')
+
+tap.test('examples to-json ipldsch', (t) => {
+  const inFile = path.join(__dirname, 'fixtures/examples.ipldsch')
+  const cli = require.resolve('../bin/cli.js')
+  const expectedSchema = require(path.join(__dirname, 'fixtures/examples.ipldsch.json'))
+
+  execFile(process.execPath, [cli, 'to-json', inFile], (err, stdout, stderr) => {
+    t.error(err)
+    t.ok(!stderr)
+
+    let schemaJson
+    try {
+      schemaJson = JSON.parse(stdout)
+    } catch (err) {
+      t.error(err)
+    }
+    t.deepEqual(schemaJson, expectedSchema)
+  }).on('close', (code) => {
+    t.equal(code, 0, 'exit code')
+    t.done()
+  })
+})
+
+tap.test('examples to-json md', (t) => {
+  const inFile = path.join(__dirname, 'fixtures/examples.ipldsch.md')
+  const cli = require.resolve('../bin/cli.js')
+  const expectedSchema = require(path.join(__dirname, 'fixtures/examples.ipldsch.json'))
+
+  execFile(process.execPath, [cli, 'to-json', inFile], (err, stdout, stderr) => {
+    t.error(err)
+    t.ok(!stderr)
+
+    let schemaJson
+    try {
+      schemaJson = JSON.parse(stdout)
+    } catch (err) {
+      t.error(err)
+    }
+    t.deepEqual(schemaJson, expectedSchema)
+  }).on('close', (code) => {
+    t.equal(code, 0, 'exit code')
+    t.done()
+  })
+})
+
+tap.test('examples validate ipldsch', (t) => {
+  const filename = 'fixtures/examples.ipldsch.md'
+  const inFile = path.join(__dirname, filename)
+  const cli = require.resolve('../bin/cli.js')
+
+  execFile(process.execPath, [cli, 'validate', inFile], (err, stdout, stderr) => {
+    t.error(err)
+    t.ok(!stdout)
+    t.contains(stderr, filename, `stderr referenced ${filename}`)
+  }).on('close', (code) => {
+    t.equal(code, 0, 'exit code')
+    t.done()
+  })
+})
+
+tap.test('examples validate md', (t) => {
+  const filename = 'fixtures/examples.ipldsch.md'
+  const inFile = path.join(__dirname, filename)
+  const cli = require.resolve('../bin/cli.js')
+
+  execFile(process.execPath, [cli, 'validate', inFile], (err, stdout, stderr) => {
+    t.error(err)
+    t.ok(!stdout)
+    t.contains(stderr, filename, `stderr referenced ${filename}`)
+  }).on('close', (code) => {
+    t.equal(code, 0, 'exit code')
+    t.done()
+  })
+})
+
+tap.test('validate failure', (t) => {
+  const inFile = path.join(__dirname, 'bork.ipldsch')
+  const cli = require.resolve('../bin/cli.js')
+
+  fs.writeFile(inFile, 'type Nope NopeNopeNope Nopity Nope nope [&{!', () => {
+    execFile(process.execPath, [cli, 'validate', inFile], (err, stdout, stderr) => {
+      fs.unlink(inFile, () => {})
+      t.ok(err)
+      t.contains(err.message, inFile)
+      t.ok(!stdout)
+      t.contains(stderr, inFile)
+    }).on('close', (code) => {
+      t.equal(code, 1, 'exit code')
+      t.done()
+    })
+  })
+})
+
+tap.test('schema-schema multi md validate', (t) => {
+  const inDir = path.join(__dirname, 'fixtures/schema-schema/')
+  const files = fs.readdirSync(inDir)
+    .map((f) => path.join(inDir, f))
+  const cli = require.resolve('../bin/cli.js')
+
+  execFile(process.execPath, [cli, 'validate'].concat(files), (err, stdout, stderr) => {
+    t.error(err)
+    t.ok(!stdout)
+    for (const f of files) {
+      t.contains(stderr, path.basename(f), `stderr referenced ${path.basename(f)}`)
+    }
+  }).on('close', (code) => {
+    t.equal(code, 0, 'exit code')
+    t.done()
+  })
+})
+
+tap.test('schema-schema multi md to-json', (t) => {
+  const inDir = path.join(__dirname, 'fixtures/schema-schema/')
+  const files = fs.readdirSync(inDir)
+    .map((f) => path.join(inDir, f))
+  const cli = require.resolve('../bin/cli.js')
+  const expectedSchema = require(path.join(__dirname, 'fixtures/schema-schema.ipldsch.json'))
+
+  execFile(process.execPath, [cli, 'to-json'].concat(files), (err, stdout, stderr) => {
+    t.error(err)
+    t.ok(!stderr)
+
+    let schemaJson
+    try {
+      schemaJson = JSON.parse(stdout)
+    } catch (err) {
+      t.error(err)
+    }
+    t.deepEqual(schemaJson, expectedSchema)
+  }).on('close', (code) => {
+    t.equal(code, 0, 'exit code')
+    t.done()
+  })
+})

--- a/test/examples-test.js
+++ b/test/examples-test.js
@@ -1,0 +1,11 @@
+const fs = require('fs').promises
+const path = require('path')
+const tap = require('tap')
+const Schema = require('../ipld-schema')
+
+tap.test('examples', async (t) => {
+  const schemaText = await fs.readFile(path.join(__dirname, 'fixtures/examples.ipldsch'), 'utf8')
+  const schema = new Schema(schemaText)
+  const expectedSchema = require(path.join(__dirname, 'fixtures/examples.ipldsch.json'))
+  t.deepEqual({ schema: schema.descriptor }, expectedSchema)
+})

--- a/test/fixtures/bulk/struct-empty.yml
+++ b/test/fixtures/bulk/struct-empty.yml
@@ -1,0 +1,20 @@
+schema: |
+  type StructEmpty struct { }
+  type StructEmptyTight struct {}
+expected: |
+  {
+    "StructEmpty": {
+      "kind": "struct",
+      "fields": {},
+      "representation": {
+        "map": {}
+      }
+    },
+    "StructEmptyTight": {
+      "kind": "struct",
+      "fields": {},
+      "representation": {
+        "map": {}
+      }
+    }
+  }

--- a/test/fixtures/examples.ipldsch
+++ b/test/fixtures/examples.ipldsch
@@ -1,0 +1,10 @@
+
+type ExampleWithNullable {String : nullable &Any}
+
+type ExampleWithAnonDefns struct {
+	fooField optional {String:String} (rename "foo_field")
+	barField nullable {String:String}
+	bazField {String : nullable String}
+	wozField {String:[nullable String]}
+	boomField &ExampleWithNullable
+} representation map

--- a/test/fixtures/examples.ipldsch.json
+++ b/test/fixtures/examples.ipldsch.json
@@ -1,0 +1,67 @@
+{
+	"schema": {
+		"ExampleWithNullable": {
+			"kind": "map",
+			"keyType": "String",
+			"valueType": {
+				"kind": "link"
+			},
+			"valueNullable": true
+		},
+		"ExampleWithAnonDefns": {
+			"kind": "struct",
+			"fields": {
+				"fooField": {
+					"type": {
+						"kind": "map",
+						"keyType": "String",
+						"valueType": "String"
+					},
+					"optional": true
+				},
+				"barField": {
+					"type": {
+						"kind": "map",
+						"keyType": "String",
+						"valueType": "String"
+					},
+					"nullable": true
+				},
+				"bazField": {
+					"type": {
+						"kind": "map",
+						"keyType": "String",
+						"valueType": "String",
+						"valueNullable": true
+					}
+				},
+				"wozField": {
+					"type": {
+						"kind": "map",
+						"keyType": "String",
+						"valueType": {
+							"kind": "list",
+							"valueType": "String",
+							"valueNullable": true
+						}
+					}
+				},
+				"boomField": {
+					"type": {
+						"kind": "link",
+						"expectedType": "ExampleWithNullable"
+					}
+				}
+			},
+			"representation": {
+				"map": {
+					"fields": {
+						"fooField": {
+							"rename": "foo_field"
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/fixtures/examples.ipldsch.md
+++ b/test/fixtures/examples.ipldsch.md
@@ -1,0 +1,31 @@
+# Examples
+
+This test is to test Markdown parsing.
+
+This is `ExampleWithNullable`, embedded in an `ipldsch` code block:
+
+```ipldsch
+type ExampleWithNullable {String : nullable &Any}
+```
+
+This is `ExampleWithNullableGo`, embedded in an `go` code block and it should not be parsed:
+
+```go
+type ExampleWithNullableGo string
+```
+
+This is `ExampleWithAnonDefns`, embedded in an `sh` code block:
+
+```sh
+type ExampleWithAnonDefns struct {
+	fooField optional {String:String} (rename "foo_field")
+	barField nullable {String:String}
+	bazField {String : nullable String}
+	wozField {String:[nullable String]}
+	boomField &ExampleWithNullable
+} representation map
+```
+
+This is ExampleWithNullableInline in an inline code block and it should not be parsed:
+
+`type ExampleWithNullableInline string`

--- a/test/fixtures/schema-schema.ipldsch
+++ b/test/fixtures/schema-schema.ipldsch
@@ -8,7 +8,8 @@
 ## There are some additional rules that should be applied:
 ##   - Type names should by convention begin with a capital letter;
 ##   - Type names must be all printable characters (no whitespace);
-##   - Type names must not contain punctuation (dashes, dots, etc).
+##   - Type names must not contain punctuation other than underscores
+##     (dashes, dots, etc.).
 ##
 ## Type names are strings meant for human consumption at a local scope.
 ## When making a Schema, note that the TypeName is the key of the map:
@@ -135,6 +136,18 @@ type RepresentationKind enum {
 	| "link"
 }
 
+## AnyScalar defines a union of the basic non-complex kinds.
+##
+## Useful defining usage of IPLD nodes that do compose from other nodes.
+##
+type AnyScalar union {
+	| Bool bool
+	| String string
+	| Bytes bytes
+	| Int int
+	| Float float
+} representation kinded
+
 ## TypeBool describes a simple boolean type.
 ## It has no details.
 ##
@@ -167,7 +180,56 @@ type TypeMap struct {
 	keyType TypeName # additionally, the referenced type must be reprkind==string.
 	valueType TypeTerm
 	valueNullable Bool (implicit "false")
+	representation MapRepresentation
 } representation map
+
+## MapRepresentation describes how a map type should be mapped onto
+## its IPLD Data Model representation.  By default a map is a map in the
+## Data Model but other kinds can be configured.
+##
+type MapRepresentation union {
+	| MapRepresentation_Map "map"
+	| MapRepresentation_StringPairs "stringpairs"
+	| MapRepresentation_ListPairs "listpairs"
+} representation keyed
+
+## MapRepresentation_Map describes that a map should be encoded as
+## a map in the Data Model
+##
+type MapRepresentation_Map struct {}
+
+## MapRepresentation_StringPairs describes that a map should be encoded as a
+## string of delimited "k/v" entries, e.g. "k1=v1,k2=v2".
+## The separating delimiter may be specified with "entryDelim", and the k/v
+## delimiter may be specified with "innerDelim". So a "k=v" naive
+## comma-separated form would use an "innerDelim" of "=" and an "entryDelim"
+## of ",".
+##
+## This serial representation is limited: the domain of keys must
+## exclude the "innerDelim" and values and keys must exclude ",".
+## There is no facility for escaping, such as in escaped CSV.
+## This also leads to a further restriction that this representation is only
+## valid for maps whose keys and values may all be encoded to string form
+## without conflicts in delimiter character. It is recommended, therefore,
+## that its use be limited to maps containing values with the basic data
+## model kinds that exclude multiple values (i.e. no maps, lists, and therefore
+## structs or unions).
+##
+type MapRepresentation_StringPairs struct {
+	innerDelim String
+	entryDelim String
+}
+
+## MapRepresentation_ListPairs describes that a map should be encoded as a
+## list in the IPLD Data Model. This list comprises a sub-list for each entry,
+## in the form: [[k1,v1],[k2,v2]].
+##
+## This representation type is similar to StructRepresentation_Tuple except
+## it includes the keys. This is critical for maps since the keys are not
+## defined in the schema (hence "tuple" representation isn't available for
+## maps).
+##
+type MapRepresentation_ListPairs struct {}
 
 ## TypeList describes a list.
 ## The values of the list have some specific type of their own.
@@ -179,10 +241,25 @@ type TypeList struct {
 
 ## TypeLink describes a hash linking to another object (a CID).
 ##
-## REVIEW: this currently has no details... but possibly it should have a
-## type hint for what we expect when resolving the link?
+## A link also has an "expectedType" that provides a hinting mechanism
+## suggesting what we should find if we were to follow the link. This
+## cannot be strictly enforced by a node or block-level schema
+## validation but may be enforced elsewhere in an application relying on
+## a schema.
 ##
-type TypeLink struct {}
+## The expectedType is specified with the `&Any` link shorthand, where
+## `Any` may be replaced with a specific type.
+##
+## Unlike other kinds, we use `&Type` to denote a link Type rather than
+## `Link`. In this usage, we replace `Type` the expected Type, with `&Any`
+## being shorthand for "a link which may resolve to a type of any kind".
+##
+## `expectedType` is a String, but it should validate as "Any" or a TypeName
+## found somewhere in the schema.
+##
+type TypeLink struct {
+	expectedType String (implicit "Any")
+}
 
 ## TypeUnion describes a union (sometimes called a "sum type", or
 ## more verbosely, a "discriminated union").
@@ -280,9 +357,23 @@ type UnionRepresentation_Inline struct {
 ## also exist).
 ##
 type TypeStruct struct {
-	fields {String:StructField}
+	fields {FieldName:StructField}
 	representation StructRepresentation
 }
+
+## FieldName is an alias of string.
+##
+## There are some additional rules that should be applied:
+##   - Field names should by convention begin with a lower-case letter;
+##   - Field names must be all printable characters (no whitespace);
+##   - Field names must not contain punctuation other than underscores
+##     (dashes, dots, etc.).
+##
+## Field names are strings meant for human consumption at a local scope.
+## When making a Schema, note that the FieldName is the key of the map:
+## a FieldName must be unique within the Schema.
+##
+type FieldName string
 
 ## StructField describes the properties of each field declared by a TypeStruct.
 ##
@@ -359,19 +450,30 @@ type InlineDefn union {
 ## StructRepresentation describes how a struct type should be mapped onto
 ## its IPLD Data Model representation.  Typically, maps are the representation
 ## kind, but other kinds and details can be configured.
+##
 type StructRepresentation union {
 	| StructRepresentation_Map "map"
 	| StructRepresentation_Tuple "tuple"
+	| StructRepresentation_StringPairs "stringpairs"
+	| StructRepresentation_StringJoin "stringjoin"
+	| StructRepresentation_ListPairs "listpairs"
 } representation keyed
 
 ## StructRepresentation_Map describes a way to map a struct type onto a map
-## representation.  For example, fields may be aliased,
-## or implicit values associated.
+## representation. Field serialization options may optionally be configured to
+## enable mapping serialized keys using the 'rename' option, or implicit values
+## specified where the field is omitted from the serialized form using the
+## 'implicit' option.
+##
+## See StructRepresentation_Map_FieldDetails for details on the 'rename' and
+## 'implicit' options.
+##
 type StructRepresentation_Map struct {
-	fields optional {String:StructRepresentation_Map_FieldDetails}
+	fields optional {FieldName:StructRepresentation_Map_FieldDetails}
 }
+
 ## StructRepresentation_Map_FieldDetails describes additional properties of a
-## struct field when represented as a map.  For example, fields may be aliased,
+## struct field when represented as a map.  For example, fields may be renamed,
 ## or implicit values associated.
 ##
 ## If an implicit value is defined, then during marshalling, if the actual value
@@ -386,14 +488,14 @@ type StructRepresentation_Map struct {
 ## By contrast, the cardinality of membership of a field with an implicit value
 ## remains unchanged; there is serial state which can map to an undefined value.
 ##
-## Note that 'alias' supports exactly one string, and not a list: this is
-## intentional.  The alias feature is meant to allow serial representations
+## Note that 'rename' supports exactly one string, and not a list: this is
+## intentional.  The rename feature is meant to allow serial representations
 ## to use a different key string than the schema type definition field name;
 ## it is not intended to be used for migration purposes.
 ##
 type StructRepresentation_Map_FieldDetails struct {
-	alias optional String
-	implicit optional Any # Review: may be better to introduce a small kinded union here which has the essential scalars as members.
+	rename optional String
+	implicit optional AnyScalar
 }
 
 ## StructRepresentation_Tuple describes a way to map a struct type into a list
@@ -402,12 +504,61 @@ type StructRepresentation_Map_FieldDetails struct {
 ## Tuple representations are less flexible than map representations:
 ## field order can be specified in order to override the order defined
 ## in the type, but optionals and implicits are not (currently) supported.
+## A `fieldOrder` list must include quoted strings (FieldName is a string
+## type) which are coerced to the names of the struct fields. e.g.:
+##   fieldOrder ["Foo", "Bar", "Baz"]
+##
 type StructRepresentation_Tuple struct {
-	fieldOrder optional [String]
+	fieldOrder optional [FieldName]
 }
+
+## StructRepresentation_StringPairs describes that a struct should be encoded
+## as a string of delimited "k/v" entries, e.g. "k1=v1,k2=v2".
+## The separating delimiter may be specified with "entryDelim", and the k/v
+## delimiter may be specified with "innerDelim". So a "k=v" naive
+## comma-separated form would use an "innerDelim" of "=" and an "entryDelim"
+## of ",".
+##
+## Serialization a struct with stringpairs works the same way as serializing
+## a map with stringpairs and the same character limitations exist. See
+## MapRepresentation_StringPairs for more details on these limitations.
+##
+type StructRepresentation_StringPairs struct {
+	innerDelim String
+	entryDelim String
+}
+
+## StructRepresentation_StringJoin describes a way to encode a struct to
+## a string in the IPLD Data Model. Similar to tuple representation, the
+## keys are dropped as they may be inferred from the struct definition.
+## values are concatenated, in order, and separated by a "join" delimiter.
+## For example, specifying ":" as the "join": "v1,v2,v3".
+##
+## stringjoin is necessarily restrictive and therefore only valid for structs
+## whose values may all be encoded to string form without conflicts in "join"
+## character. It is recommended, therefore, that its use be limited to structs
+## containing values with the basic data model kinds that exclude multiple
+## values (i.e. no maps, lists, and therefore structs or unions).
+##
+type StructRepresentation_StringJoin struct {
+	join String
+	fieldOrder optional [FieldName]
+}
+
+## StructRepresentation_ListPairs describes that a struct, should be encoded as
+## a list in the IPLD Data Model. This list comprises a sub-list for each
+## entry, in the form: [[k1,v1],[k2,v2]].
+##
+## This representation type encodes in the same way as
+## MapStructRepresentation_Tuple. It is also similar to
+## StructRepresentation_Tuple except it includes the keys in nested lists.
+## A tuple representation for a struct will encode more compact than listpairs.
+##
+type StructRepresentation_ListPairs struct {}
 
 ## TypeEnum describes a type which has a known, pre-defined set of possible
 ## values.  Each of the values must be representable a string.
+##
 type TypeEnum struct {
 	members {String:Null}
 }

--- a/test/fixtures/schema-schema.ipldsch.json
+++ b/test/fixtures/schema-schema.ipldsch.json
@@ -66,6 +66,18 @@
 				"link": null
 			}
 		},
+		"AnyScalar": {
+			"kind": "union",
+			"representation": {
+				"kinded": {
+					"bool": "Bool",
+					"string": "String",
+					"bytes": "Bytes",
+					"int": "Int",
+					"float": "Float"
+				}
+			}
+		},
 		"TypeBool": {
 			"kind": "struct",
 			"fields": {},
@@ -112,6 +124,9 @@
 				},
 				"valueNullable": {
 					"type": "Bool"
+				},
+				"representation": {
+					"type": "MapRepresentation"
 				}
 			},
 			"representation": {
@@ -122,6 +137,44 @@
 						}
 					}
 				}
+			}
+		},
+		"MapRepresentation": {
+			"kind": "union",
+			"representation": {
+				"keyed": {
+					"map": "MapRepresentation_Map",
+					"stringpairs": "MapRepresentation_StringPairs",
+					"listpairs": "MapRepresentation_ListPairs"
+				}
+			}
+		},
+		"MapRepresentation_Map": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
+			}
+		},
+		"MapRepresentation_StringPairs": {
+			"kind": "struct",
+			"fields": {
+				"innerDelim": {
+					"type": "String"
+				},
+				"entryDelim": {
+					"type": "String"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"MapRepresentation_ListPairs": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
 			}
 		},
 		"TypeList": {
@@ -146,9 +199,19 @@
 		},
 		"TypeLink": {
 			"kind": "struct",
-			"fields": {},
+			"fields": {
+				"expectedType": {
+					"type": "String"
+				}
+			},
 			"representation": {
-				"map": {}
+				"map": {
+					"fields": {
+						"expectedType": {
+							"implicit": "Any"
+						}
+					}
+				}
 			}
 		},
 		"TypeUnion": {
@@ -228,7 +291,7 @@
 				"fields": {
 					"type": {
 						"kind": "map",
-						"keyType": "String",
+						"keyType": "FieldName",
 						"valueType": "StructField"
 					}
 				},
@@ -239,6 +302,9 @@
 			"representation": {
 				"map": {}
 			}
+		},
+		"FieldName": {
+			"kind": "string"
 		},
 		"StructField": {
 			"kind": "struct",
@@ -292,7 +358,10 @@
 			"representation": {
 				"keyed": {
 					"map": "StructRepresentation_Map",
-					"tuple": "StructRepresentation_Tuple"
+					"tuple": "StructRepresentation_Tuple",
+					"stringpairs": "StructRepresentation_StringPairs",
+					"stringjoin": "StructRepresentation_StringJoin",
+					"listpairs": "StructRepresentation_ListPairs"
 				}
 			}
 		},
@@ -302,7 +371,7 @@
 				"fields": {
 					"type": {
 						"kind": "map",
-						"keyType": "String",
+						"keyType": "FieldName",
 						"valueType": "StructRepresentation_Map_FieldDetails"
 					},
 					"optional": true
@@ -315,12 +384,12 @@
 		"StructRepresentation_Map_FieldDetails": {
 			"kind": "struct",
 			"fields": {
-				"alias": {
+				"rename": {
 					"type": "String",
 					"optional": true
 				},
 				"implicit": {
-					"type": "Any",
+					"type": "AnyScalar",
 					"optional": true
 				}
 			},
@@ -334,11 +403,50 @@
 				"fieldOrder": {
 					"type": {
 						"kind": "list",
-						"valueType": "String"
+						"valueType": "FieldName"
 					},
 					"optional": true
 				}
 			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"StructRepresentation_StringPairs": {
+			"kind": "struct",
+			"fields": {
+				"innerDelim": {
+					"type": "String"
+				},
+				"entryDelim": {
+					"type": "String"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"StructRepresentation_StringJoin": {
+			"kind": "struct",
+			"fields": {
+				"join": {
+					"type": "String"
+				},
+				"fieldOrder": {
+					"type": {
+						"kind": "list",
+						"valueType": "FieldName"
+					},
+					"optional": true
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"StructRepresentation_ListPairs": {
+			"kind": "struct",
+			"fields": {},
 			"representation": {
 				"map": {}
 			}

--- a/test/fixtures/schema-schema/AnyScalar.md
+++ b/test/fixtures/schema-schema/AnyScalar.md
@@ -1,0 +1,16 @@
+# schema-schema: `AnyScalar`
+
+AnyScalar defines a union of the basic non-complex kinds.
+
+Useful defining usage of IPLD nodes that do compose from other nodes.
+
+
+```ipldsch
+type AnyScalar union {
+	| Bool bool
+	| String string
+	| Bytes bytes
+	| Int int
+	| Float float
+} representation kinded
+```

--- a/test/fixtures/schema-schema/FieldName.md
+++ b/test/fixtures/schema-schema/FieldName.md
@@ -1,0 +1,18 @@
+# schema-schema: `FieldName`
+
+FieldName is an alias of string.
+
+There are some additional rules that should be applied:
+  - Field names should by convention begin with a lower-case letter;
+  - Field names must be all printable characters (no whitespace);
+  - Field names must not contain punctuation other than underscores
+    (dashes, dots, etc.).
+
+Field names are strings meant for human consumption at a local scope.
+When making a Schema, note that the FieldName is the key of the map:
+a FieldName must be unique within the Schema.
+
+
+```ipldsch
+type FieldName string
+```

--- a/test/fixtures/schema-schema/InlineDefn.md
+++ b/test/fixtures/schema-schema/InlineDefn.md
@@ -1,0 +1,23 @@
+# schema-schema: `InlineDefn`
+
+InlineDefn represents a declaration of an anonymous type of one of the simple
+recursive kinds (e.g. map or list) which is found "inline" in another type's
+definition.  It's the more complex option of the TypeTerm union.
+
+Note that the representation of this union -- `representation inline "kind"`
+-- as well as the keywords for its members -- align exactly with those
+in the Type union.  Technically, this isn't a necessary property (in that
+nothing would break if that sameness was violated) but it's awfully nice for
+sanity; what we're saying here is that the representation of the types in an
+InlineDefn should look *exactly the same* as the top-level Types... it's just
+that we're restricted to a subset of the members.
+
+
+```ipldsch
+type InlineDefn union {
+	| TypeMap "map"
+	| TypeList "list"
+} representation inline {
+	discriminantKey "kind"
+}
+```

--- a/test/fixtures/schema-schema/MapRepresentation.md
+++ b/test/fixtures/schema-schema/MapRepresentation.md
@@ -1,0 +1,14 @@
+# schema-schema: `MapRepresentation`
+
+MapRepresentation describes how a map type should be mapped onto
+its IPLD Data Model representation.  By default a map is a map in the
+Data Model but other kinds can be configured.
+
+
+```ipldsch
+type MapRepresentation union {
+	| MapRepresentation_Map "map"
+	| MapRepresentation_StringPairs "stringpairs"
+	| MapRepresentation_ListPairs "listpairs"
+} representation keyed
+```

--- a/test/fixtures/schema-schema/MapRepresentation_ListPairs.md
+++ b/test/fixtures/schema-schema/MapRepresentation_ListPairs.md
@@ -1,0 +1,15 @@
+# schema-schema: `MapRepresentation_ListPairs`
+
+MapRepresentation_ListPairs describes that a map should be encoded as a
+list in the IPLD Data Model. This list comprises a sub-list for each entry,
+in the form: [[k1,v1],[k2,v2]].
+
+This representation type is similar to StructRepresentation_Tuple except
+it includes the keys. This is critical for maps since the keys are not
+defined in the schema (hence "tuple" representation isn't available for
+maps).
+
+
+```ipldsch
+type MapRepresentation_ListPairs struct {}
+```

--- a/test/fixtures/schema-schema/MapRepresentation_Map.md
+++ b/test/fixtures/schema-schema/MapRepresentation_Map.md
@@ -1,0 +1,9 @@
+# schema-schema: `MapRepresentation_Map`
+
+MapRepresentation_Map describes that a map should be encoded as
+a map in the Data Model
+
+
+```ipldsch
+type MapRepresentation_Map struct {}
+```

--- a/test/fixtures/schema-schema/MapRepresentation_StringPairs.md
+++ b/test/fixtures/schema-schema/MapRepresentation_StringPairs.md
@@ -1,0 +1,26 @@
+# schema-schema: `MapRepresentation_StringPairs`
+
+MapRepresentation_StringPairs describes that a map should be encoded as a
+string of delimited "k/v" entries, e.g. "k1=v1,k2=v2".
+The separating delimiter may be specified with "entryDelim", and the k/v
+delimiter may be specified with "innerDelim". So a "k=v" naive
+comma-separated form would use an "innerDelim" of "=" and an "entryDelim"
+of ",".
+
+This serial representation is limited: the domain of keys must
+exclude the "innerDelim" and values and keys must exclude ",".
+There is no facility for escaping, such as in escaped CSV.
+This also leads to a further restriction that this representation is only
+valid for maps whose keys and values may all be encoded to string form
+without conflicts in delimiter character. It is recommended, therefore,
+that its use be limited to maps containing values with the basic data
+model kinds that exclude multiple values (i.e. no maps, lists, and therefore
+structs or unions).
+
+
+```ipldsch
+type MapRepresentation_StringPairs struct {
+	innerDelim String
+	entryDelim String
+}
+```

--- a/test/fixtures/schema-schema/RepresentationKind.md
+++ b/test/fixtures/schema-schema/RepresentationKind.md
@@ -1,0 +1,28 @@
+# schema-schema: `RepresentationKind`
+
+RepresentationKind is similar to TypeKind, but includes only those concepts
+which exist at the IPLD *Data Model* level.
+
+In other words, structs, unions, and enumerations are not present:
+those concepts are introduced in the IPLD Schema system, and when serialized,
+all of them must be transformable to one of these representation kinds
+(e.g. a "struct" TypeKind will usually be transformed to a "map"
+RepresentationKind; "enum" TypeKind are always "string" RepresentationKind;
+and so on.)
+
+RepresentationKind strings are sometimes used to to indicate part of the
+definition in the details of Type; for example, they're used describing
+some of the detailed behaviors of a "kinded"-style union type.
+
+```ipldsch
+type RepresentationKind enum {
+	| "bool"
+	| "string"
+	| "bytes"
+	| "int"
+	| "float"
+	| "map"
+	| "list"
+	| "link"
+}
+```

--- a/test/fixtures/schema-schema/Schema.md
+++ b/test/fixtures/schema-schema/Schema.md
@@ -1,0 +1,23 @@
+# schema-schema: `Schema`
+
+Schema is a single-member union, which can be used in serialization
+to make a form of "nominative type declaration".
+
+A complete (if quite short) Schema might look like this:
+
+```
+{
+  "schema": {
+    "MyFooType": {
+      "type": "string"
+    }
+  }
+}
+```
+
+
+```ipldsch
+type Schema union {
+	| SchemaMap "schema"
+} representation keyed
+```

--- a/test/fixtures/schema-schema/SchemaMap.md
+++ b/test/fixtures/schema-schema/SchemaMap.md
@@ -1,0 +1,19 @@
+# schema-schema: `SchemaMap`
+
+SchemaMap is a complete set of types;
+it is simply a map of TypeName to detailed declaration of that Type.
+
+A simple schema map with one type might look like this:
+
+```
+{
+  "MyFooType": {
+    "type": "string"
+  }
+}
+```
+
+
+```ipldsch
+type SchemaMap {TypeName:Type}
+```

--- a/test/fixtures/schema-schema/StructField.md
+++ b/test/fixtures/schema-schema/StructField.md
@@ -1,0 +1,38 @@
+# schema-schema: `StructField`
+
+StructField describes the properties of each field declared by a TypeStruct.
+
+StructField contains properties similar to TypeMap -- namely, it describes
+a content type (as a TypeTerm -- it supports inline definitions) -- and
+has a boolean property for whether or not the value is permitted to be null.
+
+In addition, StructField also has a property called "optional".
+An "optional" field is one which is permitted to be absent entirely.
+This is distinct from "nullable": a field can be optional=false and
+nullable=true, in which case it's an error if the key is missing entirely,
+but null is of course valid.  Conversely, if a field is optional=true and
+nullable=false, it's an error if the field is present and assigned null, but
+fine for a map to be missing a key of the field's name entirely and still be
+recognized as this struct.
+(The specific behavior of optionals may vary per StructRepresentation.)
+
+Note that the 'optional' and 'nullable' properties are not themselves
+optional... however, in the IPLD serial representation of schemas, you'll
+often see them absent from the map encoding a StructField.  This is because
+these fields are specified to be implicitly false.
+Implicits in a map representation of a struct mean that those entries may
+be missing from the map encoding... but unlike with "optional" fields, there
+is no "undefined" value; absence is simply interpreted as the value specified
+as the implicit.
+(With implicit fields, an explicitly encoded implicit value is actually an
+error instead!)  "Optional" fields give rise to N+1 cardinality logic,
+just like "nullable" fields; "implicit" fields *do not*.
+
+
+```ipldsch
+type StructField struct {
+	type TypeTerm
+	optional Bool (implicit "false")
+	nullable Bool (implicit "false")
+} representation map
+```

--- a/test/fixtures/schema-schema/StructRepresentation.md
+++ b/test/fixtures/schema-schema/StructRepresentation.md
@@ -1,0 +1,16 @@
+# schema-schema: `StructRepresentation`
+
+StructRepresentation describes how a struct type should be mapped onto
+its IPLD Data Model representation.  Typically, maps are the representation
+kind, but other kinds and details can be configured.
+
+
+```ipldsch
+type StructRepresentation union {
+	| StructRepresentation_Map "map"
+	| StructRepresentation_Tuple "tuple"
+	| StructRepresentation_StringPairs "stringpairs"
+	| StructRepresentation_StringJoin "stringjoin"
+	| StructRepresentation_ListPairs "listpairs"
+} representation keyed
+```

--- a/test/fixtures/schema-schema/StructRepresentation_ListPairs.md
+++ b/test/fixtures/schema-schema/StructRepresentation_ListPairs.md
@@ -1,0 +1,15 @@
+# schema-schema: `StructRepresentation_ListPairs`
+
+StructRepresentation_ListPairs describes that a struct, should be encoded as
+a list in the IPLD Data Model. This list comprises a sub-list for each
+entry, in the form: [[k1,v1],[k2,v2]].
+
+This representation type encodes in the same way as
+MapStructRepresentation_Tuple. It is also similar to
+StructRepresentation_Tuple except it includes the keys in nested lists.
+A tuple representation for a struct will encode more compact than listpairs.
+
+
+```ipldsch
+type StructRepresentation_ListPairs struct {}
+```

--- a/test/fixtures/schema-schema/StructRepresentation_Map.md
+++ b/test/fixtures/schema-schema/StructRepresentation_Map.md
@@ -1,0 +1,17 @@
+# schema-schema: `StructRepresentation_Map`
+
+StructRepresentation_Map describes a way to map a struct type onto a map
+representation. Field serialization options may optionally be configured to
+enable mapping serialized keys using the 'rename' option, or implicit values
+specified where the field is omitted from the serialized form using the
+'implicit' option.
+
+See StructRepresentation_Map_FieldDetails for details on the 'rename' and
+'implicit' options.
+
+
+```ipldsch
+type StructRepresentation_Map struct {
+	fields optional {FieldName:StructRepresentation_Map_FieldDetails}
+}
+```

--- a/test/fixtures/schema-schema/StructRepresentation_Map_FieldDetails.md
+++ b/test/fixtures/schema-schema/StructRepresentation_Map_FieldDetails.md
@@ -1,0 +1,30 @@
+# schema-schema: `StructRepresentation_Map_FieldDetails`
+
+StructRepresentation_Map_FieldDetails describes additional properties of a
+struct field when represented as a map.  For example, fields may be renamed,
+or implicit values associated.
+
+If an implicit value is defined, then during marshalling, if the actual value
+is the implicit value, that field will be omitted from the map; and during
+unmarshalling, correspondingly, the absence of that field will be interpreted
+as being the implicit value.
+
+Note that fields with implicits are distinct from fields which are optional!
+The cardinality of membership of an optional field is is incremented:
+e.g., the cardinality of "fieldname Bool" is 2; "fieldname optional Bool" is
+membership cardinality *3*, because it may also be undefined.
+By contrast, the cardinality of membership of a field with an implicit value
+remains unchanged; there is serial state which can map to an undefined value.
+
+Note that 'rename' supports exactly one string, and not a list: this is
+intentional.  The rename feature is meant to allow serial representations
+to use a different key string than the schema type definition field name;
+it is not intended to be used for migration purposes.
+
+
+```ipldsch
+type StructRepresentation_Map_FieldDetails struct {
+	rename optional String
+	implicit optional AnyScalar
+}
+```

--- a/test/fixtures/schema-schema/StructRepresentation_StringJoin.md
+++ b/test/fixtures/schema-schema/StructRepresentation_StringJoin.md
@@ -1,0 +1,21 @@
+# schema-schema: `StructRepresentation_StringJoin`
+
+StructRepresentation_StringJoin describes a way to encode a struct to
+a string in the IPLD Data Model. Similar to tuple representation, the
+keys are dropped as they may be inferred from the struct definition.
+values are concatenated, in order, and separated by a "join" delimiter.
+For example, specifying ":" as the "join": "v1,v2,v3".
+
+stringjoin is necessarily restrictive and therefore only valid for structs
+whose values may all be encoded to string form without conflicts in "join"
+character. It is recommended, therefore, that its use be limited to structs
+containing values with the basic data model kinds that exclude multiple
+values (i.e. no maps, lists, and therefore structs or unions).
+
+
+```ipldsch
+type StructRepresentation_StringJoin struct {
+	join String
+	fieldOrder optional [FieldName]
+}
+```

--- a/test/fixtures/schema-schema/StructRepresentation_StringPairs.md
+++ b/test/fixtures/schema-schema/StructRepresentation_StringPairs.md
@@ -1,0 +1,20 @@
+# schema-schema: `StructRepresentation_StringPairs`
+
+StructRepresentation_StringPairs describes that a struct should be encoded
+as a string of delimited "k/v" entries, e.g. "k1=v1,k2=v2".
+The separating delimiter may be specified with "entryDelim", and the k/v
+delimiter may be specified with "innerDelim". So a "k=v" naive
+comma-separated form would use an "innerDelim" of "=" and an "entryDelim"
+of ",".
+
+Serialization a struct with stringpairs works the same way as serializing
+a map with stringpairs and the same character limitations exist. See
+MapRepresentation_StringPairs for more details on these limitations.
+
+
+```ipldsch
+type StructRepresentation_StringPairs struct {
+	innerDelim String
+	entryDelim String
+}
+```

--- a/test/fixtures/schema-schema/StructRepresentation_Tuple.md
+++ b/test/fixtures/schema-schema/StructRepresentation_Tuple.md
@@ -1,0 +1,18 @@
+# schema-schema: `StructRepresentation_Tuple`
+
+StructRepresentation_Tuple describes a way to map a struct type into a list
+representation.
+
+Tuple representations are less flexible than map representations:
+field order can be specified in order to override the order defined
+in the type, but optionals and implicits are not (currently) supported.
+A `fieldOrder` list must include quoted strings (FieldName is a string
+type) which are coerced to the names of the struct fields. e.g.:
+  fieldOrder ["Foo", "Bar", "Baz"]
+
+
+```ipldsch
+type StructRepresentation_Tuple struct {
+	fieldOrder optional [FieldName]
+}
+```

--- a/test/fixtures/schema-schema/Type.md
+++ b/test/fixtures/schema-schema/Type.md
@@ -1,0 +1,45 @@
+# schema-schema: `The`
+
+The types of Type are a union.
+
+The Type union is serialized using "inline" union representation,
+which means all of its members have map representations, and there will be
+an entry in that map called "type" which contains the union discriminant.
+
+Some of the kinds of type are so simple the union discriminant is the only
+content at all, e.g. strings:
+
+```
+{
+  "type": "string"
+}
+```
+
+Other types have more content.  Consider this example of a map type:
+
+```
+{
+  "type": "map",
+  "keyType": "String",
+  "valueType": "Int"
+}
+```
+
+
+```ipldsch
+type Type union {
+	| TypeBool "bool"
+	| TypeString "string"
+	| TypeBytes "bytes"
+	| TypeInt "int"
+	| TypeFloat "float"
+	| TypeMap "map"
+	| TypeList "list"
+	| TypeLink "link"
+	| TypeUnion "union"
+	| TypeStruct "struct"
+	| TypeEnum "enum"
+} representation inline {
+	discriminantKey "kind"
+}
+```

--- a/test/fixtures/schema-schema/TypeBool.md
+++ b/test/fixtures/schema-schema/TypeBool.md
@@ -1,0 +1,9 @@
+# schema-schema: `TypeBool`
+
+TypeBool describes a simple boolean type.
+It has no details.
+
+
+```ipldsch
+type TypeBool struct {}
+```

--- a/test/fixtures/schema-schema/TypeBytes.md
+++ b/test/fixtures/schema-schema/TypeBytes.md
@@ -1,0 +1,9 @@
+# schema-schema: `TypeBytes`
+
+TypeBytes describes a simple byte array type.
+It has no details.
+
+
+```ipldsch
+type TypeBytes struct {}
+```

--- a/test/fixtures/schema-schema/TypeEnum.md
+++ b/test/fixtures/schema-schema/TypeEnum.md
@@ -1,0 +1,11 @@
+# schema-schema: `TypeEnum`
+
+TypeEnum describes a type which has a known, pre-defined set of possible
+values.  Each of the values must be representable a string.
+
+
+```ipldsch
+type TypeEnum struct {
+	members {String:Null}
+}
+```

--- a/test/fixtures/schema-schema/TypeFloat.md
+++ b/test/fixtures/schema-schema/TypeFloat.md
@@ -1,0 +1,9 @@
+# schema-schema: `TypeFloat`
+
+TypeFloat describes a simple floating point numeric type.
+It has no details.
+
+
+```ipldsch
+type TypeFloat struct {}
+```

--- a/test/fixtures/schema-schema/TypeInt.md
+++ b/test/fixtures/schema-schema/TypeInt.md
@@ -1,0 +1,9 @@
+# schema-schema: `TypeInt`
+
+TypeInt describes a simple integer numeric type.
+It has no details.
+
+
+```ipldsch
+type TypeInt struct {}
+```

--- a/test/fixtures/schema-schema/TypeKind.md
+++ b/test/fixtures/schema-schema/TypeKind.md
@@ -1,0 +1,24 @@
+# schema-schema: `TypeKind`
+
+TypeKind enumerates all the major kinds of type.
+Notice this enum's members are the same as the set of strings used as
+discriminants in the Type union.
+
+TODO: not actually sure we'll need to declare this.  Only usage is
+in the Type union representation details?
+
+```ipldsch
+type TypeKind enum {
+	| "bool"
+	| "string"
+	| "bytes"
+	| "int"
+	| "float"
+	| "map"
+	| "list"
+	| "link"
+	| "union"
+	| "struct"
+	| "enum"
+}
+```

--- a/test/fixtures/schema-schema/TypeLink.md
+++ b/test/fixtures/schema-schema/TypeLink.md
@@ -1,0 +1,26 @@
+# schema-schema: `TypeLink`
+
+TypeLink describes a hash linking to another object (a CID).
+
+A link also has an "expectedType" that provides a hinting mechanism
+suggesting what we should find if we were to follow the link. This
+cannot be strictly enforced by a node or block-level schema
+validation but may be enforced elsewhere in an application relying on
+a schema.
+
+The expectedType is specified with the `&Any` link shorthand, where
+`Any` may be replaced with a specific type.
+
+Unlike other kinds, we use `&Type` to denote a link Type rather than
+`Link`. In this usage, we replace `Type` the expected Type, with `&Any`
+being shorthand for "a link which may resolve to a type of any kind".
+
+`expectedType` is a String, but it should validate as "Any" or a TypeName
+found somewhere in the schema.
+
+
+```ipldsch
+type TypeLink struct {
+	expectedType String (implicit "Any")
+}
+```

--- a/test/fixtures/schema-schema/TypeList.md
+++ b/test/fixtures/schema-schema/TypeList.md
@@ -1,0 +1,12 @@
+# schema-schema: `TypeList`
+
+TypeList describes a list.
+The values of the list have some specific type of their own.
+
+
+```ipldsch
+type TypeList struct {
+	valueType TypeTerm
+	valueNullable Bool (implicit "false")
+} representation map
+```

--- a/test/fixtures/schema-schema/TypeMap.md
+++ b/test/fixtures/schema-schema/TypeMap.md
@@ -1,0 +1,14 @@
+# schema-schema: `TypeMap`
+
+TypeMap describes a key-value map.
+The keys and values of the map have some specific type of their own.
+
+
+```ipldsch
+type TypeMap struct {
+	keyType TypeName # additionally, the referenced type must be reprkind==string.
+	valueType TypeTerm
+	valueNullable Bool (implicit "false")
+	representation MapRepresentation
+} representation map
+```

--- a/test/fixtures/schema-schema/TypeName.md
+++ b/test/fixtures/schema-schema/TypeName.md
@@ -1,0 +1,18 @@
+# schema-schema: `Type`
+
+Type names are a simple alias of string.
+
+There are some additional rules that should be applied:
+  - Type names should by convention begin with a capital letter;
+  - Type names must be all printable characters (no whitespace);
+  - Type names must not contain punctuation other than underscores
+    (dashes, dots, etc.).
+
+Type names are strings meant for human consumption at a local scope.
+When making a Schema, note that the TypeName is the key of the map:
+a TypeName must be unique within the Schema.
+
+
+```ipldsch
+type TypeName string
+```

--- a/test/fixtures/schema-schema/TypeString.md
+++ b/test/fixtures/schema-schema/TypeString.md
@@ -1,0 +1,9 @@
+# schema-schema: `TypeString`
+
+TypeString describes a simple string type.
+It has no details.
+
+
+```ipldsch
+type TypeString struct {}
+```

--- a/test/fixtures/schema-schema/TypeStruct.md
+++ b/test/fixtures/schema-schema/TypeStruct.md
@@ -1,0 +1,18 @@
+# schema-schema: `TypeStruct`
+
+TypeStruct describes a type which has a group of fields of varying Type.
+Each field has a name, which is used to access its value, similarly to
+accessing values in a map.
+
+The most typical representation of a struct is as a map, in which case field
+names also serve as the the map keys (though this is a default, and details
+of this representation may be configured; and other representation strategies
+also exist).
+
+
+```ipldsch
+type TypeStruct struct {
+	fields {FieldName:StructField}
+	representation StructRepresentation
+}
+```

--- a/test/fixtures/schema-schema/TypeTerm.md
+++ b/test/fixtures/schema-schema/TypeTerm.md
@@ -1,0 +1,23 @@
+# schema-schema: `TypeTerm`
+
+TypeTerm is a union of either TypeName or an InlineDefn. th It's used for the
+value type in the recursive types (maps, lists, and the fields of structs),
+which allows the use of InlineDefn in any of those positions.
+
+TypeTerm is simply a TypeName if the kind of data is a string; this is the
+simple case.
+
+Note that TypeTerm isn't used to describe *keys* in the recursive types that
+have them (maps, structs) -- recursive types in keys would not lend itself
+well to serialization!
+TypeTerm also isn't used to describe members in Unions -- this is a choice
+aimed to limit syntactical complexity (both at type definition authoring
+time, as well as for the sake of error messaging during typechecking).
+
+
+```ipldsch
+type TypeTerm union {
+	| TypeName string
+	| InlineDefn map
+} representation kinded
+```

--- a/test/fixtures/schema-schema/TypeUnion.md
+++ b/test/fixtures/schema-schema/TypeUnion.md
@@ -1,0 +1,21 @@
+# schema-schema: `TypeUnion`
+
+TypeUnion describes a union (sometimes called a "sum type", or
+more verbosely, a "discriminated union").
+A union is a type that can have a value of several different types, but
+unlike maps or structs, in a union only one of those values may be present
+at a time.
+
+Unions can be defined as representing in several different ways: see
+the documentation on the UnionRepresentation type for details.
+
+The set of types which the union can contain are specified in a map
+inside the representation field.  (The key type of the map varies per
+representation strategy, so it's not possible to keep on this type directly.)
+
+
+```ipldsch
+type TypeUnion struct {
+	representation UnionRepresentation
+}
+```

--- a/test/fixtures/schema-schema/UnionRepresentation.md
+++ b/test/fixtures/schema-schema/UnionRepresentation.md
@@ -1,0 +1,22 @@
+# schema-schema: `UnionRepresentation`
+
+UnionRepresentation is a union of all the distinct ways a TypeUnion's values
+can be mapped onto a serialized format for the IPLD Data Model.
+
+There are "keyed", "envelop", and "inline" strategies, which are all ways
+to produce representations in a map format (some literature may describe
+this as "tagged" style unions), and a fourth style, "kinded" unions, may
+actually encode itself as any of the other representation kinds!
+
+Note: Unions can be used to produce a "nominative" style of type declarations
+-- yes, even given that IPLD Schema systems are natively "structural" typing!
+
+
+```ipldsch
+type UnionRepresentation union {
+	| UnionRepresentation_Kinded "kinded"
+	| UnionRepresentation_Keyed "keyed"
+	| UnionRepresentation_Envelope "envelope"
+	| UnionRepresentation_Inline "inline"
+} representation keyed
+```

--- a/test/fixtures/schema-schema/UnionRepresentation_Envelope.md
+++ b/test/fixtures/schema-schema/UnionRepresentation_Envelope.md
@@ -1,0 +1,16 @@
+# schema-schema: `Envelope`
+
+"Envelope" union representations will encode as a map, where the map has
+exactly two entries: the two keys should be of the exact strings specified
+for this envelope representation.  The value for the discriminant key
+should be one of the strings in the discriminant table.  The value for
+the content key should be the content, and be of the Type matching the
+lookup in the discriminant table.
+
+```ipldsch
+type UnionRepresentation_Envelope struct {
+	discriminantKey String
+	contentKey String
+	discriminantTable {String:TypeName}
+}
+```

--- a/test/fixtures/schema-schema/UnionRepresentation_Inline.md
+++ b/test/fixtures/schema-schema/UnionRepresentation_Inline.md
@@ -1,0 +1,25 @@
+# schema-schema: `Inline`
+
+"Inline" union representations require that all of their members encode
+as a map, and encode their type info into the same map as the member data.
+Thus, the map for an inline union may have any number of entries: it is
+however many fields the member value has, plus one (for the discriminant).
+
+All members of an inline union must be struct types and must encode to
+the map RepresentationKind.  Other types which encode to map (such as map
+types themselves!) cannot be used: the potential for content values with
+with keys overlapping with the discriminantKey would result in undefined
+behavior!  Similarly, the member struct types may not have fields which
+have names that collide with the discriminantKey.
+
+When designing a new protocol, use inline unions sparringly; despite
+appearing simple, they have the most edge cases of any kind of union
+representation, and their implementation is generally the most complex and
+is difficult to optimize deserialization to support.
+
+```ipldsch
+type UnionRepresentation_Inline struct {
+	discriminantKey String
+	discriminantTable {String:TypeName}
+}
+```

--- a/test/fixtures/schema-schema/UnionRepresentation_Keyed.md
+++ b/test/fixtures/schema-schema/UnionRepresentation_Keyed.md
@@ -1,0 +1,14 @@
+# schema-schema: `Keyed`
+
+"Keyed" union representations will encode as a map, where the map has
+exactly one entry, the key string of which will be used to look up the name
+of the Type; and the value should be the content, and be of that Type.
+
+Note: when writing a new protocol, it may be wise to prefer keyed unions
+over the other styles wherever possible; keyed unions tend to have good
+performance characteristics, as they have most "mechanical sympathy" with
+parsing and deserialization implementation order.
+
+```ipldsch
+type UnionRepresentation_Keyed {String:TypeName}
+```

--- a/test/fixtures/schema-schema/UnionRepresentation_Kinded.md
+++ b/test/fixtures/schema-schema/UnionRepresentation_Kinded.md
@@ -1,0 +1,12 @@
+# schema-schema: `Kinded`
+
+"Kinded" union representations describe a bidirectional mapping between
+a RepresentationKind and a Type (referenced by name) which should be the
+union member decoded when one sees this RepresentationKind.
+
+The referenced type must of course produce the RepresentationKind it's
+matched with!
+
+```ipldsch
+type UnionRepresentation_Kinded {RepresentationKind:TypeName}
+```


### PR DESCRIPTION
main pieces are in bin/

the stuff in tests/ is adding tests for the CLI features (currently there are none), _including_ splitting the schema-schema into an .md file per `type` and parsing them back in `to-json` and comparing to the schema-schema json. Check those cool fixtures out @ https://github.com/ipld/js-ipld-schema/tree/rvagg/to-json-moar/test/fixtures/schema-schema
