### PR TITLE
implement `ipld-schema to-schema` schema format reprinting 

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,6 +2,15 @@
 
 const validate = require('./validate')
 const toJSON = require('./to-json')
+const toSchema = require('./to-schema')
+
+const toOpts = {
+  tabs: {
+    alias: 't',
+    type: 'boolean',
+    describe: 'print with tabs instead of spaces'
+  }
+}
 
 const yargs = require('yargs')
   .scriptName('ipld-schema')
@@ -10,13 +19,10 @@ const yargs = require('yargs')
     'Accepts .ipldsch and .md files, if none are passed will read from stdin, returns exit code 0 on successful validation')
   .command('to-json',
     'Accepts .ipldsch files, if none are passed will read from stdin, prints the JSON form of the schema',
-    {
-      tabs: {
-        alias: 't',
-        type: 'boolean',
-        describe: 'print with tabs instead of spaces'
-      }
-    })
+    toOpts)
+  .command('to-schema',
+    'Accepts .ipldsch and .md files, if none are passed will read from stdin, prints the canonical IPLD Schema form of the schema',
+    toOpts)
   .showHelpOnFail()
   .demandCommand(1, 'must provide a valid command')
   .help()
@@ -35,6 +41,9 @@ switch (yargs.argv._[0]) {
     break
   case 'to-json':
     runCommand(toJSON)
+    break
+  case 'to-schema':
+    runCommand(toSchema)
     break
   default:
     yargs.showHelp()

--- a/bin/collect-input.js
+++ b/bin/collect-input.js
@@ -52,7 +52,7 @@ async function collectInput (files) {
 
   input = input.filter(({ filename, contents }) => {
     if (!contents) {
-      console.error(`Ignoring "${filename}" (no IPLD Schema contents)`)
+      console.error(`Ignoring "${filename}" (no IPLD Schema content)`)
       return false
     }
     return true

--- a/bin/to-schema.js
+++ b/bin/to-schema.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+const parser = require('../parser')
+const print = require('../print')
+const { transformError } = require('../util')
+const collectInput = require('./collect-input')
+
+let indent = '  '
+
+async function toSchema (files, options) {
+  if (options.tabs) {
+    indent = '\t'
+  }
+
+  const input = await collectInput(files)
+
+  let schema
+  for (const { filename, contents } of input) {
+    try {
+      const parsed = parser.parse(contents)
+      if (!schema) {
+        schema = parsed
+      } else {
+        for (const [type, defn] of Object.entries(parsed.schema)) {
+          if (schema.schema[type]) {
+            console.error(`Error: duplicate type "${type}" found in schema(s)`)
+            return process.exit(1)
+          }
+          schema.schema[type] = defn
+        }
+      }
+    } catch (err) {
+      console.error(`Error parsing ${filename}: ${transformError(err).message}`)
+      process.exit(1)
+    }
+  }
+
+  console.log(print(schema, indent))
+}
+
+module.exports = toSchema

--- a/ipld-schema.js
+++ b/ipld-schema.js
@@ -22,7 +22,7 @@ class Schema {
 }
 
 function findTypeDescriptor (schema, typeName) {
-  const type = schema.descriptor[typeName] || kindTypes[typeName]
+  const type = schema.descriptor.schema[typeName] || kindTypes[typeName]
 
   if (typeof type !== 'object') {
     throw new Error(`Root type '${typeName}' not found in schema`)
@@ -292,7 +292,7 @@ function isKindedUnion (type) {
 
 function parse (text) {
   try {
-    return parser.parse(text).schema
+    return parser.parse(text)
   } catch (err) {
     throw transformError(err)
   }

--- a/print.js
+++ b/print.js
@@ -1,0 +1,241 @@
+function print (schema, indent = '  ') {
+  if (!schema || typeof schema.schema !== 'object') {
+    throw new Error('Invalid schema')
+  }
+
+  let str = ''
+
+  for (const [type, defn] of Object.entries(schema.schema)) {
+    if (typeof defn.kind !== 'string') {
+      throw new Error(`Invalid schema ${type} doesn't have a kind`)
+    }
+
+    str += `type ${type} ${printType(defn, indent)}\n\n`
+  }
+
+  return str.replace(/\n\n$/m, '')
+}
+
+function printType (defn, indent) {
+  if (['map', 'list', 'link'].includes(defn.kind)) {
+    return printTypeTerm(defn, indent)
+  }
+  if (['struct', 'union', 'enum'].includes(defn.kind)) {
+    return `${defn.kind} ${printTypeTerm(defn, indent)}`
+  }
+  return defn.kind
+}
+
+function printTypeTerm (defn, indent) {
+  if (typeof defn === 'string') {
+    return defn
+  }
+
+  if (typeof printTypeTerm[defn.kind] !== 'function') {
+    console.log('blurp', defn)
+    throw new Error(`Invalid schema unsupported kind (${defn.kind})`)
+  }
+
+  return printTypeTerm[defn.kind](defn, indent)
+}
+
+printTypeTerm.link = function link (defn) {
+  return `&${printTypeTerm(defn.expectedType || 'Any')}`
+}
+
+printTypeTerm.map = function map (defn, indent) {
+  if (typeof defn.keyType !== 'string') {
+    throw new Error('Invalid schema, map definition needs a "keyType"')
+  }
+  if (!defn.valueType) {
+    throw new Error('Invalid schema, map definition needs a "keyType"')
+  }
+
+  const nullable = defn.valueNullable === true ? 'nullable ' : ''
+  let str = `{${printTypeTerm(defn.keyType)}:${nullable}${printTypeTerm(defn.valueType)}}`
+  if (defn.representation) {
+    if (typeof defn.representation.listpairs === 'object') {
+      str += ' representation listpairs'
+    } else if (typeof defn.representation.stringpairs === 'object') {
+      str += stringpairs(indent, 'map', defn.representation.stringpairs)
+    }
+  }
+  return str
+}
+
+printTypeTerm.list = function list (defn) {
+  if (!defn.valueType) {
+    throw new Error('Invalid schema, list definition needs a "keyType"')
+  }
+
+  const nullable = defn.valueNullable === true ? 'nullable ' : ''
+  return `[${nullable}${printTypeTerm(defn.valueType)}]`
+}
+
+printTypeTerm.struct = function struct (defn, indent) {
+  if (typeof defn.fields !== 'object') {
+    throw new Error('Invalid schema, struct requires a "fields" map')
+  }
+
+  let str = '{'
+
+  for (const [name, fieldDefn] of Object.entries(defn.fields)) {
+    const optional = fieldDefn.optional === true ? 'optional ' : ''
+    const nullable = fieldDefn.nullable === true ? 'nullable ' : ''
+    let fieldRepr = ''
+    if (defn.representation && defn.representation.map && typeof defn.representation.map.fields === 'object') {
+      const fr = defn.representation.map.fields[name]
+      if (typeof fr === 'object') {
+        const hasRename = typeof fr.rename === 'string'
+        const hasImplicit = fr.implicit !== undefined
+        if (hasRename || hasImplicit) {
+          fieldRepr = ' ('
+          if (hasRename) {
+            fieldRepr += `rename "${fr.rename}"`
+            if (hasImplicit) {
+              fieldRepr += ' '
+            }
+          }
+          if (hasImplicit) {
+            fieldRepr += `implicit "${fr.implicit}"`
+          }
+          fieldRepr += ')'
+        }
+      }
+    }
+
+    const fieldType = typeof fieldDefn.type === 'string' ? fieldDefn.type : printTypeTerm(fieldDefn.type)
+    str += `\n${indent}${name} ${optional}${nullable}${fieldType}${fieldRepr}`
+  }
+
+  if (str[str.length - 1] !== '{') {
+    str += '\n'
+  }
+  str += '}'
+
+  if (defn.representation) {
+    if (typeof defn.representation.listpairs === 'object') {
+      str += ' representation listpairs'
+    } else if (typeof defn.representation.stringjoin === 'object') {
+      if (typeof defn.representation.stringjoin.join !== 'string') {
+        throw new Error('Invalid schema, struct stringjoin representations require an join string')
+      }
+      str += ' representation stringjoin {\n'
+      str += `${indent}join "${defn.representation.stringjoin.join}"\n`
+      str += fieldOrder(indent, defn.representation.stringjoin.fieldOrder)
+      str += '}'
+    } else if (typeof defn.representation.stringpairs === 'object') {
+      str += stringpairs(indent, 'struct', defn.representation.stringpairs)
+    } else if (typeof defn.representation.tuple === 'object') {
+      str += ' representation tuple'
+      if (Array.isArray(defn.representation.tuple.fieldOrder)) {
+        str += ' {\n'
+        str += fieldOrder(indent, defn.representation.tuple.fieldOrder)
+        str += '}'
+      }
+    } else if (typeof defn.representation.stringpairs === 'object') {
+      str += stringpairs(indent, 'struct', defn.representation.stringpairs)
+    }
+  }
+
+  return str
+}
+
+function fieldOrder (indent, fieldOrder) {
+  let str = ''
+  if (Array.isArray(fieldOrder)) {
+    const fo = fieldOrder.map((f) => `"${f}"`).join(', ')
+    str += `${indent}fieldOrder [${fo}]\n`
+  }
+  return str
+}
+
+function stringpairs (indent, kind, stringpairs) {
+  let str = ''
+  if (typeof stringpairs.innerDelim !== 'string') {
+    throw new Error(`Invalid schema, ${kind} stringpairs representations require an innerDelim string`)
+  }
+  if (typeof stringpairs.entryDelim !== 'string') {
+    throw new Error(`Invalid schema, ${kind} stringpairs representations require an entryDelim string`)
+  }
+  str += ' representation stringpairs {\n'
+  str += `${indent}innerDelim "${stringpairs.innerDelim}"\n`
+  str += `${indent}entryDelim "${stringpairs.entryDelim}"\n`
+  str += '}'
+  return str
+}
+
+printTypeTerm.union = function union (defn, indent) {
+  if (typeof defn.representation !== 'object') {
+    throw new Error('Invalid schema, unions require a representation')
+  }
+
+  let str = '{'
+
+  if (typeof defn.representation.kinded === 'object') {
+    for (const [kind, type] of Object.entries(defn.representation.kinded)) {
+      str += `\n${indent}| ${printTypeTerm(type)} ${kind}`
+    }
+    str += '\n} representation kinded'
+  } else if (typeof defn.representation.keyed === 'object') {
+    for (const [key, type] of Object.entries(defn.representation.keyed)) {
+      str += `\n${indent}| ${printTypeTerm(type)} "${key}"`
+    }
+    str += '\n} representation keyed'
+  } else if (typeof defn.representation.byteprefix === 'object') {
+    for (const [type, key] of Object.entries(defn.representation.byteprefix)) {
+      str += `\n${indent}| ${printTypeTerm(type)} ${key}`
+    }
+    str += '\n} representation byteprefix'
+  } else if (typeof defn.representation.inline === 'object') {
+    if (typeof defn.representation.inline.discriminantTable !== 'object') {
+      throw new Error('Invalid schema, inline unions require a discriminantTable map')
+    }
+    if (typeof defn.representation.inline.discriminantKey !== 'string') {
+      throw new Error('Invalid schema, inline unions require a discriminantKey string')
+    }
+    for (const [key, type] of Object.entries(defn.representation.inline.discriminantTable)) {
+      str += `\n${indent}| ${printTypeTerm(type)} "${key}"`
+    }
+    str += `\n} representation inline {\n${indent}discriminantKey "${defn.representation.inline.discriminantKey}"\n}`
+  } else if (typeof defn.representation.envelope === 'object') {
+    if (typeof defn.representation.envelope.discriminantTable !== 'object') {
+      throw new Error('Invalid schema, envelope unions require a discriminantTable map')
+    }
+    if (typeof defn.representation.envelope.discriminantKey !== 'string') {
+      throw new Error('Invalid schema, envelope unions require a discriminantKey string')
+    }
+    if (typeof defn.representation.envelope.contentKey !== 'string') {
+      throw new Error('Invalid schema, envelope unions require a contentKey string')
+    }
+    for (const [key, type] of Object.entries(defn.representation.envelope.discriminantTable)) {
+      str += `\n${indent}| ${printTypeTerm(type)} "${key}"`
+    }
+    str += '\n} representation envelope {'
+    str += `\n${indent}discriminantKey "${defn.representation.envelope.discriminantKey}"`
+    str += `\n${indent}contentKey "${defn.representation.envelope.contentKey}"`
+    str += '\n}'
+  } else {
+    throw new Error(`Invalid schema, unknown union representation type ${Object.keys(defn.representation)[0]}`)
+  }
+
+  return str
+}
+
+printTypeTerm.enum = function _enum (defn, indent) {
+  if (typeof defn.members !== 'object') {
+    throw new Error('Invalid schema, enum requires a "members" map')
+  }
+
+  let str = '{'
+
+  for (const [key] of Object.entries(defn.members)) {
+    // TODO handle int enums, unquote keys
+    str += `\n${indent}| "${key}"`
+  }
+
+  str += '\n}'
+  return str
+}
+
+module.exports = print

--- a/test/bulk-fixtures-test.js
+++ b/test/bulk-fixtures-test.js
@@ -3,6 +3,7 @@ const path = require('path')
 const yaml = require('js-yaml')
 const tap = require('tap')
 const Schema = require('../ipld-schema')
+const print = require('../print')
 
 fs.readdirSync(path.join(__dirname, 'fixtures/bulk')).map((f) => {
   if (!f.endsWith('.yml')) {
@@ -14,11 +15,19 @@ fs.readdirSync(path.join(__dirname, 'fixtures/bulk')).map((f) => {
     const testName = `fixture ${f}`
     // assume the root type is the first listed (default for the only type listed), otherwise
     // if there is a 'root' in the fixture, use that
-    const rootType = fixture.root || Object.keys(fixture.expected)[0]
+    const rootType = fixture.root || Object.keys(fixture.expected.schema)[0]
 
     t.test(`${testName}: schema parse`, (t) => {
       const schema = new Schema(fixture.schema)
       t.deepEqual(schema.descriptor, fixture.expected, `parsing ${testName}`)
+      t.done()
+    })
+
+    t.test(`${testName}: schema canonical`, (t) => {
+      const schema = new Schema(fixture.schema)
+      const schemaCanonical = print(schema.descriptor)
+      const expected = fixture.canonical || fixture.schema
+      t.deepEqual(schemaCanonical, expected.replace(/\n+$/, ''), `canonicalizing ${testName}`)
       t.done()
     })
 

--- a/test/examples-test.js
+++ b/test/examples-test.js
@@ -7,5 +7,5 @@ tap.test('examples', async (t) => {
   const schemaText = await fs.readFile(path.join(__dirname, 'fixtures/examples.ipldsch'), 'utf8')
   const schema = new Schema(schemaText)
   const expectedSchema = require(path.join(__dirname, 'fixtures/examples.ipldsch.json'))
-  t.deepEqual({ schema: schema.descriptor }, expectedSchema)
+  t.deepEqual(schema.descriptor, expectedSchema)
 })

--- a/test/fixtures/bulk/bytes.yml
+++ b/test/fixtures/bulk/bytes.yml
@@ -2,7 +2,9 @@ schema: |
   type SimpleBytes bytes
 expected: |
   {
-    "SimpleBytes": {
-      "kind": "bytes"
+    "schema": {
+      "SimpleBytes": {
+        "kind": "bytes"
+      }
     }
   }

--- a/test/fixtures/bulk/enum.yml
+++ b/test/fixtures/bulk/enum.yml
@@ -6,12 +6,14 @@ schema: |
   }
 expected: |
   {
-    "SimpleEnum": {
-      "kind": "enum",
-      "members": {
-        "foo": null,
-        "bar": null,
-        "baz": null
+    "schema": {
+      "SimpleEnum": {
+        "kind": "enum",
+        "members": {
+          "foo": null,
+          "bar": null,
+          "baz": null
+        }
       }
     }
   }

--- a/test/fixtures/bulk/float.yml
+++ b/test/fixtures/bulk/float.yml
@@ -2,8 +2,10 @@ schema: |
   type SimpleFloat float
 expected: |
   {
-    "SimpleFloat": {
-      "kind": "float"
+    "schema": {
+      "SimpleFloat": {
+        "kind": "float"
+      }
     }
   }
 blocks:

--- a/test/fixtures/bulk/int.yml
+++ b/test/fixtures/bulk/int.yml
@@ -2,8 +2,10 @@ schema: |
   type SimpleInt int
 expected: |
   {
-    "SimpleInt": {
-      "kind": "int"
+    "schema": {
+      "SimpleInt": {
+        "kind": "int"
+      }
     }
   }
 blocks:

--- a/test/fixtures/bulk/link-inline.yml
+++ b/test/fixtures/bulk/link-inline.yml
@@ -1,40 +1,44 @@
 schema: |
   type Bar {String:&Baz}
+
   type Baz struct {
     boom String
     foo &Foo
   }
+
   type Foo [Int]
 root: Foo
 expected: |
   {
-    "Bar": {
-      "keyType": "String",
-      "kind": "map",
-      "valueType": {
-        "kind": "link",
-        "expectedType": "Baz"
-      }
-    },
-    "Baz": {
-      "fields": {
-        "boom": {
-          "type": "String"
-        },
-        "foo": {
-          "type": {
-            "kind": "link",
-            "expectedType": "Foo"
-          }
+    "schema": {
+      "Bar": {
+        "keyType": "String",
+        "kind": "map",
+        "valueType": {
+          "kind": "link",
+          "expectedType": "Baz"
         }
       },
-      "kind": "struct",
-      "representation": {
-        "map": {}
+      "Baz": {
+        "fields": {
+          "boom": {
+            "type": "String"
+          },
+          "foo": {
+            "type": {
+              "kind": "link",
+              "expectedType": "Foo"
+            }
+          }
+        },
+        "kind": "struct",
+        "representation": {
+          "map": {}
+        }
+      },
+      "Foo": {
+        "kind": "list",
+        "valueType": "Int"
       }
-    },
-    "Foo": {
-      "kind": "list",
-      "valueType": "Int"
     }
   }

--- a/test/fixtures/bulk/link-kinded-union.yml
+++ b/test/fixtures/bulk/link-kinded-union.yml
@@ -3,52 +3,56 @@ schema: |
     | File map
     | &File link
   } representation kinded
+
   type File struct {
     name optional String
     data optional DataUnion
   }
+
   type DataUnion union {
     | Data bytes
     | &Data link
   } representation kinded
 expected: |
   {
-    "FileUnion": {
-      "kind": "union",
-      "representation": {
-        "kinded": {
-          "map": "File",
-          "link": {
-            "kind": "link",
-            "expectedType": "File"
+    "schema": {
+      "FileUnion": {
+        "kind": "union",
+        "representation": {
+          "kinded": {
+            "map": "File",
+            "link": {
+              "kind": "link",
+              "expectedType": "File"
+            }
           }
         }
-      }
-    },
-    "File": {
-      "kind": "struct",
-      "fields": {
-        "name": {
-          "type": "String",
-          "optional": true
+      },
+      "File": {
+        "kind": "struct",
+        "fields": {
+          "name": {
+            "type": "String",
+            "optional": true
+          },
+          "data": {
+            "type": "DataUnion",
+            "optional": true
+          }
         },
-        "data": {
-          "type": "DataUnion",
-          "optional": true
+        "representation": {
+          "map": {}
         }
       },
-      "representation": {
-        "map": {}
-      }
-    },
-    "DataUnion": {
-      "kind": "union",
-      "representation": {
-        "kinded": {
-          "bytes": "Data",
-          "link": {
-            "kind": "link",
-            "expectedType": "Data"
+      "DataUnion": {
+        "kind": "union",
+        "representation": {
+          "kinded": {
+            "bytes": "Data",
+            "link": {
+              "kind": "link",
+              "expectedType": "Data"
+            }
           }
         }
       }

--- a/test/fixtures/bulk/link-typed.yml
+++ b/test/fixtures/bulk/link-typed.yml
@@ -1,14 +1,17 @@
 schema: |
   type FooLink &Foo
+
   type Foo bytes
 root: FooLink
 expected: |
   {
-    "FooLink": {
-      "kind": "link",
-      "expectedType": "Foo"
-    },
-    "Foo": {
-      "kind": "bytes"
+    "schema": {
+      "FooLink": {
+        "kind": "link",
+        "expectedType": "Foo"
+      },
+      "Foo": {
+        "kind": "bytes"
+      }
     }
   }

--- a/test/fixtures/bulk/link.yml
+++ b/test/fixtures/bulk/link.yml
@@ -2,7 +2,9 @@ schema: |
   type SimpleLink &Any
 expected: |
   {
-    "SimpleLink": {
-      "kind": "link"
+    "schema": {
+      "SimpleLink": {
+        "kind": "link"
+      }
     }
   }

--- a/test/fixtures/bulk/list.yml
+++ b/test/fixtures/bulk/list.yml
@@ -2,9 +2,11 @@ schema: |
   type SimpleList [String]
 expected: |
   {
-    "SimpleList": {
-      "kind": "list",
-      "valueType": "String"
+    "schema": {
+      "SimpleList": {
+        "kind": "list",
+        "valueType": "String"
+      }
     }
   }
 blocks:

--- a/test/fixtures/bulk/map-listpairs.yml
+++ b/test/fixtures/bulk/map-listpairs.yml
@@ -2,10 +2,12 @@ schema: |
   type MapAsListpairs {String:String} representation listpairs
 expected: |
   {
-    "MapAsListpairs": {
-      "kind": "map",
-      "keyType": "String",
-      "valueType": "String",
-      "representation": { "listpairs": {} }
+    "schema": {
+      "MapAsListpairs": {
+        "kind": "map",
+        "keyType": "String",
+        "valueType": "String",
+        "representation": { "listpairs": {} }
+      }
     }
   }

--- a/test/fixtures/bulk/map-stringpairs.yml
+++ b/test/fixtures/bulk/map-stringpairs.yml
@@ -5,14 +5,16 @@ schema: |
   }
 expected: |
   {
-    "MapAsStringpairs": {
-      "kind": "map",
-      "keyType": "String",
-      "valueType": "String",
-      "representation": {
-        "stringpairs": {
-          "innerDelim": "=",
-          "entryDelim": ","
+    "schema": {
+      "MapAsStringpairs": {
+        "kind": "map",
+        "keyType": "String",
+        "valueType": "String",
+        "representation": {
+          "stringpairs": {
+            "innerDelim": "=",
+            "entryDelim": ","
+          }
         }
       }
     }

--- a/test/fixtures/bulk/map-with-nullable.yml
+++ b/test/fixtures/bulk/map-with-nullable.yml
@@ -2,10 +2,12 @@ schema: |
   type MapWithNullable {String:nullable String}
 expected: |
   {
-    "MapWithNullable": {
-      "kind": "map",
-      "keyType": "String",
-      "valueType": "String",
-      "valueNullable": true
+    "schema": {
+      "MapWithNullable": {
+        "kind": "map",
+        "keyType": "String",
+        "valueType": "String",
+        "valueNullable": true
+      }
     }
   }

--- a/test/fixtures/bulk/map.yml
+++ b/test/fixtures/bulk/map.yml
@@ -2,10 +2,12 @@ schema: |
   type SimpleMap {String:Int}
 expected: |
   {
-    "SimpleMap": {
-      "kind": "map",
-      "keyType": "String",
-      "valueType": "Int"
+    "schema": {
+      "SimpleMap": {
+        "kind": "map",
+        "keyType": "String",
+        "valueType": "Int"
+      }
     }
   }
 blocks:

--- a/test/fixtures/bulk/struct-empty.yml
+++ b/test/fixtures/bulk/struct-empty.yml
@@ -1,20 +1,27 @@
 schema: |
   type StructEmpty struct { }
+
+  type StructEmptyTight struct {}
+canonical: |
+  type StructEmpty struct {}
+
   type StructEmptyTight struct {}
 expected: |
   {
-    "StructEmpty": {
-      "kind": "struct",
-      "fields": {},
-      "representation": {
-        "map": {}
-      }
-    },
-    "StructEmptyTight": {
-      "kind": "struct",
-      "fields": {},
-      "representation": {
-        "map": {}
+    "schema": {
+      "StructEmpty": {
+        "kind": "struct",
+        "fields": {},
+        "representation": {
+          "map": {}
+        }
+      },
+      "StructEmptyTight": {
+        "kind": "struct",
+        "fields": {},
+        "representation": {
+          "map": {}
+        }
       }
     }
   }

--- a/test/fixtures/bulk/struct-listpairs.yml
+++ b/test/fixtures/bulk/struct-listpairs.yml
@@ -6,19 +6,22 @@ schema: |
   } representation listpairs
 expected: |
   {
-    "StructAsListpairs": {
-      "kind": "struct",
-      "fields": {
-        "foo": {
-          "type": "Int"
+    "schema": {
+      "StructAsListpairs": {
+        "kind": "struct",
+        "fields": {
+          "foo": {
+            "type": "Int"
+          },
+          "bar": {
+            "type": "Bool"
+          },
+          "baz": {
+            "type": "String"
+          }
         },
-        "bar": {
-          "type": "Bool"
-        },
-        "baz": {
-          "type": "String"
-        }
-      },
-      "representation": { "listpairs": {} }
+        "representation": { "listpairs": {} }
+      }
     }
   }
+

--- a/test/fixtures/bulk/struct-map-with-implicits.yml
+++ b/test/fixtures/bulk/struct-map-with-implicits.yml
@@ -7,28 +7,30 @@ schema: |
   }
 expected: |
   {
-    "StructAsMapWithImplicits": {
-      "kind": "struct",
-      "fields": {
-        "bar": {
-          "type": "Bool"
+    "schema": {
+      "StructAsMapWithImplicits": {
+        "kind": "struct",
+        "fields": {
+          "bar": {
+            "type": "Bool"
+          },
+          "boom": {
+            "type": "String"
+          },
+          "baz": {
+            "type": "String"
+          },
+          "foo": {
+            "type": "Int"
+          }
         },
-        "boom": {
-          "type": "String"
-        },
-        "baz": {
-          "type": "String"
-        },
-        "foo": {
-          "type": "Int"
-        }
-      },
-      "representation": {
-        "map": {
-          "fields": {
-            "bar": { "implicit": false },
-            "boom": { "implicit": "yay" },
-            "foo": { "implicit": 0 }
+        "representation": {
+          "map": {
+            "fields": {
+              "bar": { "implicit": false },
+              "boom": { "implicit": "yay" },
+              "foo": { "implicit": 0 }
+            }
           }
         }
       }

--- a/test/fixtures/bulk/struct-map-with-renames.yml
+++ b/test/fixtures/bulk/struct-map-with-renames.yml
@@ -3,34 +3,36 @@ schema: |
     bar Bool (rename "b")
     boom String
     baz String (rename "z")
-    foo Int (implicit "0" rename "f")
+    foo Int (rename "f" implicit "0")
   }
 expected: |
   {
-    "StructAsMapWithRenames": {
-      "kind": "struct",
-      "fields": {
-        "bar": {
-          "type": "Bool"
+    "schema": {
+      "StructAsMapWithRenames": {
+        "kind": "struct",
+        "fields": {
+          "bar": {
+            "type": "Bool"
+          },
+          "boom": {
+            "type": "String"
+          },
+          "baz": {
+            "type": "String"
+          },
+          "foo": {
+            "type": "Int"
+          }
         },
-        "boom": {
-          "type": "String"
-        },
-        "baz": {
-          "type": "String"
-        },
-        "foo": {
-          "type": "Int"
-        }
-      },
-      "representation": {
-        "map": {
-          "fields": {
-            "bar": { "rename": "b" },
-            "baz": { "rename": "z" },
-            "foo": {
-              "implicit": 0,
-              "rename": "f"
+        "representation": {
+          "map": {
+            "fields": {
+              "bar": { "rename": "b" },
+              "baz": { "rename": "z" },
+              "foo": {
+                "implicit": 0,
+                "rename": "f"
+              }
             }
           }
         }

--- a/test/fixtures/bulk/struct-stringjoin-custom-fieldorder.yml
+++ b/test/fixtures/bulk/struct-stringjoin-custom-fieldorder.yml
@@ -9,27 +9,29 @@ schema: |
   }
 expected: |
   {
-    "StructAsStringjoin": {
-      "kind": "struct",
-      "fields": {
-        "foo": {
-          "type": "Int"
+    "schema": {
+      "StructAsStringjoin": {
+        "kind": "struct",
+        "fields": {
+          "foo": {
+            "type": "Int"
+          },
+          "bar": {
+            "type": "Bool"
+          },
+          "baz": {
+            "type": "String"
+          }
         },
-        "bar": {
-          "type": "Bool"
-        },
-        "baz": {
-          "type": "String"
-        }
-      },
-      "representation": {
-        "stringjoin": {
-          "fieldOrder": [
-            "baz",
-            "bar",
-            "foo"
-          ],
-          "join": ":"
+        "representation": {
+          "stringjoin": {
+            "fieldOrder": [
+              "baz",
+              "bar",
+              "foo"
+            ],
+            "join": ":"
+          }
         }
       }
     }

--- a/test/fixtures/bulk/struct-stringjoin.yml
+++ b/test/fixtures/bulk/struct-stringjoin.yml
@@ -8,21 +8,23 @@ schema: |
   }
 expected: |
   {
-    "StructAsStringjoin": {
-      "kind": "struct",
-      "fields": {
-        "foo": {
-          "type": "Int"
+    "schema": {
+      "StructAsStringjoin": {
+        "kind": "struct",
+        "fields": {
+          "foo": {
+            "type": "Int"
+          },
+          "bar": {
+            "type": "Bool"
+          },
+          "baz": {
+            "type": "String"
+          }
         },
-        "bar": {
-          "type": "Bool"
-        },
-        "baz": {
-          "type": "String"
+        "representation": {
+          "stringjoin": { "join": ":" }
         }
-      },
-      "representation": {
-        "stringjoin": { "join": ":" }
       }
     }
   }

--- a/test/fixtures/bulk/struct-stringpairs.yml
+++ b/test/fixtures/bulk/struct-stringpairs.yml
@@ -9,23 +9,25 @@ schema: |
   }
 expected: |
   {
-    "StructAsStringpairs": {
-      "kind": "struct",
-      "fields": {
-        "foo": {
-          "type": "Int"
+    "schema": {
+      "StructAsStringpairs": {
+        "kind": "struct",
+        "fields": {
+          "foo": {
+            "type": "Int"
+          },
+          "bar": {
+            "type": "Bool"
+          },
+          "baz": {
+            "type": "String"
+          }
         },
-        "bar": {
-          "type": "Bool"
-        },
-        "baz": {
-          "type": "String"
-        }
-      },
-      "representation": {
-        "stringpairs": {
-          "innerDelim": "=",
-          "entryDelim": ","
+        "representation": {
+          "stringpairs": {
+            "innerDelim": "=",
+            "entryDelim": ","
+          }
         }
       }
     }

--- a/test/fixtures/bulk/struct-tuple-custom-fieldorder.yml
+++ b/test/fixtures/bulk/struct-tuple-custom-fieldorder.yml
@@ -8,26 +8,28 @@ schema: |
   }
 expected: |
   {
-    "StructAsTupleWithCustomFieldorder": {
-      "kind": "struct",
-      "fields": {
-        "foo": {
-          "type": "Int"
+    "schema": {
+      "StructAsTupleWithCustomFieldorder": {
+        "kind": "struct",
+        "fields": {
+          "foo": {
+            "type": "Int"
+          },
+          "bar": {
+            "type": "Bool"
+          },
+          "baz": {
+            "type": "String"
+          }
         },
-        "bar": {
-          "type": "Bool"
-        },
-        "baz": {
-          "type": "String"
-        }
-      },
-      "representation": {
-        "tuple": {
-          "fieldOrder": [
-            "baz",
-            "bar",
-            "foo"
-          ]
+        "representation": {
+          "tuple": {
+            "fieldOrder": [
+              "baz",
+              "bar",
+              "foo"
+            ]
+          }
         }
       }
     }

--- a/test/fixtures/bulk/struct-tuple.yml
+++ b/test/fixtures/bulk/struct-tuple.yml
@@ -1,4 +1,3 @@
-
 schema: |
   type StructTuple struct {
     foo Int
@@ -7,21 +6,23 @@ schema: |
   } representation tuple
 expected: |
   {
-    "StructTuple": {
-      "kind": "struct",
-      "fields": {
-        "foo": {
-          "type": "Int"
+    "schema": {
+      "StructTuple": {
+        "kind": "struct",
+        "fields": {
+          "foo": {
+            "type": "Int"
+          },
+          "bar": {
+            "type": "Bool"
+          },
+          "baz": {
+            "type": "String"
+          }
         },
-        "bar": {
-          "type": "Bool"
-        },
-        "baz": {
-          "type": "String"
+        "representation": {
+          "tuple": {}
         }
-      },
-      "representation": {
-        "tuple": {}
       }
     }
   }

--- a/test/fixtures/bulk/struct-with-anonymous-types.yml
+++ b/test/fixtures/bulk/struct-with-anonymous-types.yml
@@ -7,47 +7,50 @@ schema: |
   }
 expected: |
   {
-    "StructWithAnonymousTypes": {
-      "kind": "struct",
-      "fields": {
-        "fooField": {
-          "type": {
-            "kind": "map",
-            "keyType": "String",
-            "valueType": "String"
+    "schema": {
+      "StructWithAnonymousTypes": {
+        "kind": "struct",
+        "fields": {
+          "fooField": {
+            "type": {
+              "kind": "map",
+              "keyType": "String",
+              "valueType": "String"
+            },
+            "optional": true
           },
-          "optional": true
-        },
-        "barField": {
-          "type": {
-            "kind": "map",
-            "keyType": "String",
-            "valueType": "String"
+          "barField": {
+            "type": {
+              "kind": "map",
+              "keyType": "String",
+              "valueType": "String"
+            },
+            "nullable": true
           },
-          "nullable": true
-        },
-        "bazField": {
-          "type": {
-            "kind": "map",
-            "keyType": "String",
-            "valueType": "String",
-            "valueNullable": true
-          }
-        },
-        "wozField": {
-          "type": {
-            "kind": "map",
-            "keyType": "String",
-            "valueType": {
-              "kind": "list",
+          "bazField": {
+            "type": {
+              "kind": "map",
+              "keyType": "String",
               "valueType": "String",
               "valueNullable": true
             }
+          },
+          "wozField": {
+            "type": {
+              "kind": "map",
+              "keyType": "String",
+              "valueType": {
+                "kind": "list",
+                "valueType": "String",
+                "valueNullable": true
+              }
+            }
           }
+        },
+        "representation": {
+          "map": {}
         }
-      },
-      "representation": {
-        "map": {}
       }
     }
   }
+

--- a/test/fixtures/bulk/struct.yml
+++ b/test/fixtures/bulk/struct.yml
@@ -6,21 +6,23 @@ schema: |
   }
 expected: |
   {
-    "SimpleStruct": {
-      "kind": "struct",
-      "fields": {
-        "foo": {
-          "type": "Int"
+    "schema": {
+      "SimpleStruct": {
+        "kind": "struct",
+        "fields": {
+          "foo": {
+            "type": "Int"
+          },
+          "bar": {
+            "type": "Bool"
+          },
+          "baz": {
+            "type": "String"
+          }
         },
-        "bar": {
-          "type": "Bool"
-        },
-        "baz": {
-          "type": "String"
+        "representation": {
+          "map": {}
         }
-      },
-      "representation": {
-        "map": {}
       }
     }
   }

--- a/test/fixtures/bulk/union-byteprefix.yml
+++ b/test/fixtures/bulk/union-byteprefix.yml
@@ -1,6 +1,8 @@
 schema: |
   type Bls12_381Signature bytes
+
   type Secp256k1Signature bytes
+
   type Signature union {
     | Secp256k1Signature 0
     | Bls12_381Signature 1
@@ -8,18 +10,20 @@ schema: |
 root: Signature
 expected: |
   {
-    "Bls12_381Signature": {
-      "kind": "bytes"
-    },
-    "Secp256k1Signature": {
-      "kind": "bytes"
-    },
-    "Signature": {
-      "kind": "union",
-      "representation": {
-        "byteprefix": {
-          "Secp256k1Signature": 0,
-          "Bls12_381Signature": 1
+    "schema": {
+      "Bls12_381Signature": {
+        "kind": "bytes"
+      },
+      "Secp256k1Signature": {
+        "kind": "bytes"
+      },
+      "Signature": {
+        "kind": "union",
+        "representation": {
+          "byteprefix": {
+            "Secp256k1Signature": 0,
+            "Bls12_381Signature": 1
+          }
         }
       }
     }

--- a/test/fixtures/bulk/union-envelope.yml
+++ b/test/fixtures/bulk/union-envelope.yml
@@ -1,7 +1,10 @@
 schema: |
   type Bar bool
+
   type Baz string
+
   type Foo int
+
   type UnionEnvelope union {
     | Foo "foo"
     | Bar "bar"
@@ -13,25 +16,27 @@ schema: |
 root: UnionEnvelope
 expected: |
   {
-    "Bar": {
-      "kind": "bool"
-    },
-    "Baz": {
-      "kind": "string"
-    },
-    "Foo": {
-      "kind": "int"
-    },
-    "UnionEnvelope": {
-      "kind": "union",
-      "representation": {
-        "envelope": {
-          "discriminantKey": "bim",
-          "contentKey": "bam",
-          "discriminantTable": {
-            "foo": "Foo",
-            "bar": "Bar",
-            "baz": "Baz"
+    "schema": {
+      "Bar": {
+        "kind": "bool"
+      },
+      "Baz": {
+        "kind": "string"
+      },
+      "Foo": {
+        "kind": "int"
+      },
+      "UnionEnvelope": {
+        "kind": "union",
+        "representation": {
+          "envelope": {
+            "discriminantKey": "bim",
+            "contentKey": "bam",
+            "discriminantTable": {
+              "foo": "Foo",
+              "bar": "Bar",
+              "baz": "Baz"
+            }
           }
         }
       }

--- a/test/fixtures/bulk/union-inline.yml
+++ b/test/fixtures/bulk/union-inline.yml
@@ -2,9 +2,11 @@ schema: |
   type Bar struct {
     bral String
   }
+
   type Foo struct {
     froz Bool
   }
+
   type UnionInline union {
     | Foo "foo"
     | Bar "bar"
@@ -14,38 +16,40 @@ schema: |
 root: UnionInline
 expected: |
   {
-    "UnionInline": {
-      "kind": "union",
-      "representation": {
-        "inline": {
-          "discriminantKey": "tag",
-          "discriminantTable": {
-            "foo": "Foo",
-            "bar": "Bar"
+    "schema": {
+      "UnionInline": {
+        "kind": "union",
+        "representation": {
+          "inline": {
+            "discriminantKey": "tag",
+            "discriminantTable": {
+              "foo": "Foo",
+              "bar": "Bar"
+            }
           }
         }
-      }
-    },
-    "Foo": {
-      "kind": "struct",
-      "fields": {
-        "froz": {
-          "type": "Bool"
+      },
+      "Foo": {
+        "kind": "struct",
+        "fields": {
+          "froz": {
+            "type": "Bool"
+          }
+        },
+        "representation": {
+          "map": {}
         }
       },
-      "representation": {
-        "map": {}
-      }
-    },
-    "Bar": {
-      "kind": "struct",
-      "fields": {
-        "bral": {
-          "type": "String"
+      "Bar": {
+        "kind": "struct",
+        "fields": {
+          "bral": {
+            "type": "String"
+          }
+        },
+        "representation": {
+          "map": {}
         }
-      },
-      "representation": {
-        "map": {}
       }
     }
   }

--- a/test/fixtures/bulk/union-keyed.yml
+++ b/test/fixtures/bulk/union-keyed.yml
@@ -6,13 +6,15 @@ schema: |
   } representation keyed
 expected: |
   {
-    "UnionKeyed": {
-      "kind": "union",
-      "representation": {
-        "keyed": {
-          "bar": "Bool",
-          "foo": "Int",
-          "baz": "String"
+    "schema": {
+      "UnionKeyed": {
+        "kind": "union",
+        "representation": {
+          "keyed": {
+            "bar": "Bool",
+            "foo": "Int",
+            "baz": "String"
+          }
         }
       }
     }

--- a/test/fixtures/bulk/union-kinded.yml
+++ b/test/fixtures/bulk/union-kinded.yml
@@ -1,7 +1,10 @@
 schema: |
   type Bar bool
+
   type Baz string
+
   type Foo int
+
   type UnionKinded union {
     | Foo int
     | Bar bool
@@ -10,22 +13,24 @@ schema: |
 root: UnionKinded
 expected: |
   {
-    "Bar": {
-      "kind": "bool"
-    },
-    "Baz": {
-      "kind": "string"
-    },
-    "Foo": {
-      "kind": "int"
-    },
-    "UnionKinded": {
-      "kind": "union",
-      "representation": {
-        "kinded": {
-          "int": "Foo",
-          "bool": "Bar",
-          "string": "Baz"
+    "schema": {
+      "Bar": {
+        "kind": "bool"
+      },
+      "Baz": {
+        "kind": "string"
+      },
+      "Foo": {
+        "kind": "int"
+      },
+      "UnionKinded": {
+        "kind": "union",
+        "representation": {
+          "kinded": {
+            "int": "Foo",
+            "bool": "Bar",
+            "string": "Baz"
+          }
         }
       }
     }

--- a/test/schema-schema-test.js
+++ b/test/schema-schema-test.js
@@ -7,5 +7,5 @@ tap.test('schema-schema', async (t) => {
   const schemaText = await fs.readFile(path.join(__dirname, 'fixtures/schema-schema.ipldsch'), 'utf8')
   const schema = new Schema(schemaText)
   const expectedSchema = require(path.join(__dirname, 'fixtures/schema-schema.ipldsch.json'))
-  t.deepEqual({ schema: schema.descriptor }, expectedSchema)
+  t.deepEqual(schema.descriptor, expectedSchema)
 })


### PR DESCRIPTION
Introduces a print.js that takes an internal (JSON) schema representation and spits out the canonical format schema. Same functionality as the go-schema-ipld `ipld-schema to-schema` command. This also includes the functionality from #14 so `ipld-schema to-schema` can take stdin, multiple files and markdown files.

So for Filecoin specs schamas (in .md) we can do this kind of thing:

<img width="747" alt="Screenshot 2019-09-16 11 17 10" src="https://user-images.githubusercontent.com/495647/64930374-938f6e00-d873-11e9-9805-77e81ecdd473.png">

which extracts the schemas and canonicalises them together in one place. The warnings at the top are stderr so the stdout could be redirected easily to form a valid .ipldsch file. (`ipld-schema to-json` and `ipld-schema validate` operate in the same way as this).